### PR TITLE
Fix incorrect method names in tests

### DIFF
--- a/tests/cudamatrix/cu-device-test.py
+++ b/tests/cudamatrix/cu-device-test.py
@@ -51,15 +51,15 @@ if __name__ == '__main__':
 		from kaldi.cudamatrix import CuDevice
 
 		for loop in range(2):
-			CuDevice.Instantiate().SetDebugStrideMode(True)
+			CuDevice.instantiate().set_debug_stride_mode(True)
 			if loop == 0:
-				CuDevice.Instantiate().SelectGpuId("no")
+				CuDevice.instantiate().select_gpu_id("no")
 			else:
-				CuDevice.Instantiate().SelectGpuId("yes")
+				CuDevice.instantiate().select_gpu_id("yes")
 
 			testCudaMatrixResize()
 
-			CuDevice.Instantiate().PrintProfile()
+			CuDevice.instantiate().print_profile()
 
 	else:
 		testCudaMatrixResize()

--- a/tests/cudamatrix/cu-matrix-test.py
+++ b/tests/cudamatrix/cu-matrix-test.py
@@ -123,16 +123,16 @@ class TestCuMatrix(unittest.TestCase):
 if __name__ == '__main__':
     if cuda_available():
         from kaldi.cudamatrix import CuDevice
-    
+
         for i in range(2):
-            CuDevice.Instantiate().SetDebugStrideMode(True)
+            CuDevice.instantiate().set_debug_stride_mode(True)
             if i == 0:
-                CuDevice.Instantiate().SelectGpuId("no")
+                CuDevice.instantiate().select_gpu_id("no")
             else:
-                CuDevice.Instantiate().SelectGpuId("yes")
+                CuDevice.instantiate().select_gpu_id("yes")
 
             unittest.main()
 
-            CuDevice.Instantiate().PrintProfile()
+            CuDevice.instantiate().print_profile()
     else:
         unittest.main()

--- a/tests/cudamatrix/cu-vector-test.py
+++ b/tests/cudamatrix/cu-vector-test.py
@@ -123,16 +123,17 @@ class TestCuVector(unittest.TestCase):
 
 if __name__ == '__main__':
     if cuda_available():
+        from kaldi.cudamatrix import CuDevice
 
         for i in range(2):
-            CuDevice.Instantiate().SetDebugStrideMode(True)
+            CuDevice.instantiate().set_debug_stride_mode(True)
             if i == 0:
-                CuDevice.Instantiate().SelectGpuId("no")
+                CuDevice.instantiate().select_gpu_id("no")
             else:
-                CuDevice.Instantiate().SelectGpuId("yes")
+                CuDevice.instantiate().select_gpu_id("yes")
 
             unittest.main()
 
-            CuDevice.Instantiate().PrintProfile()
+            CuDevice.instantiate().print_profile()
     else:
         unittest.main()

--- a/tests/nnet3/nnet-compute-test.py
+++ b/tests/nnet3/nnet-compute-test.py
@@ -156,7 +156,7 @@ class TestNnetCompute(unittest.TestCase):
 if __name__ == '__main__':
     for i in range(2):
         if cuda_available():
-            from kaldi.cudamatrix.device import CuDevice
+            from kaldi.cudamatrix import CuDevice
             CuDevice.instantiate().set_debug_stride_mode(True)
             if i == 0:
                 CuDevice.instantiate().select_gpu_id("no")

--- a/tests/util/test-kaldi-table.py
+++ b/tests/util/test-kaldi-table.py
@@ -172,6 +172,3 @@ class TestKaldiTable(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
-
-


### PR DESCRIPTION
With this I cat get all tests passing in Python level.

```
> for f in $(find ./tests -type f -name "*.py"); do {python $f} done
...

Testing NumGauss: 5, Dim: 1
.LOG ([5.3.58~1-29832a]:RandPosdefSpMatrix():model-test-common.cc:37) Condition number of random matrix large 141.508, trying again (this is normal)
LOG ([5.3.58~1-29832a]:RandPosdefSpMatrix():model-test-common.cc:37) Condition number of random matrix large 655.004, trying again (this is normal)
WARNING ([5.3.58~1-29832a]:MleFullGmmUpdate():mle-full-gmm.cc:365) Too little data - removing Gaussian (weight 0.017886, occupation count 89.428716, vector size 12)
Objf change per frame was 0.069203125 vs. predicted 0.0819
.
----------------------------------------------------------------------
Ran 2 tests in 0.114s

OK
```