### PR TITLE
test: Fix non-deterministic test failure in full-gmm-test

### DIFF
--- a/tests/gmm/full-gmm-test.py
+++ b/tests/gmm/full-gmm-test.py
@@ -55,6 +55,8 @@ def init_rand_diag_gmm(gmm):
     gmm.compute_gconsts()
 
 class TestFullGmm(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(12345)
 
     def testFullGmmEst(self):
         fgmm = FullGmm()


### PR DESCRIPTION
```
> python tests/gmm/full-gmm-test.py                 
Testing NumGauss: 8, Dim: 9
Condition number of random matrix large 472.8905029296875, trying again (this is normal)
Condition number of random matrix large 120.27950286865234, trying again (this is normal)
Condition number of random matrix large 302.9361572265625, trying again (this is normal)
FObjf change per frame was 0.060371875 vs. predicted 0.06
.
======================================================================
FAIL: testFullGmm (__main__.TestFullGmm)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/gmm/full-gmm-test.py", line 154, in testFullGmm
    self.assertAlmostEqual(loglikes.log_sum_exp(), loglike_gmm2)
AssertionError: -16.53398323059082 != -16.533985137939453 within 7 places

----------------------------------------------------------------------
Ran 2 tests in 0.076s

FAILED (failures=1)
```