### PR TITLE
Fix build when users specify PYCLIF/CLIF_MATCHE/KALDI_DIR with relative paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ MAKE_NUM_JOBS = os.getenv('MAKE_NUM_JOBS', NPROC)
 
 if not PYCLIF:
     PYCLIF = os.path.join(sys.prefix, 'bin/clif-matcher')
+PYCLIF = os.path.abspath(PYCLIF)
 
 if not (os.path.isfile(PYCLIF) and os.access(PYCLIF, os.X_OK)):
     try:
@@ -50,6 +51,7 @@ if not (os.path.isfile(PYCLIF) and os.access(PYCLIF, os.X_OK)):
 
 if not CLIF_MATCHER:
     CLIF_MATCHER = os.path.join(sys.prefix, 'clang/bin/clif-matcher')
+CLIF_MATCHER = os.path.abspath(CLIF_MATCHER)
 
 if not (os.path.isfile(CLIF_MATCHER) and os.access(CLIF_MATCHER, os.X_OK)):
     print("\nCould not find clif-matcher.\nPlease make sure CLIF was installed "
@@ -65,6 +67,7 @@ CLIF_CXX_FLAGS="-I{}/include".format(RESOURCE_DIR)
 
 if not KALDI_DIR:
     KALDI_DIR = os.path.join(CWD, "tools/kaldi")
+KALDI_DIR = os.path.abspath(KALDI_DIR)
 
 KALDI_MK_PATH = os.path.join(KALDI_DIR, "src", "kaldi.mk")
 if not os.path.isfile(KALDI_MK_PATH):


### PR DESCRIPTION
e.g, 
```
DEBUG=1 PYCLIF=~/opt/clif/bin/pyclif \
KALDI_DIR=../kaldi-for-pykaldi \ # relative path here
CLIF_MATCHER=~/opt/clif/clang/bin/clif-matcher \
python setup.py develop
```

the command above produces the following `file not found` errors:

```
[  2%] Generating chain-datastruct-clifwrap.cc, chain-datastruct-clifwrap.h, chain-datastruct-clifwrap-init.cc
cd /home/ryuichi/Dropbox/asr/pykaldi/build/kaldi/chain && /home/ryuichi/opt/clif/bin/pyclif --py3output --matcher_bin=/home/ryuichi/opt/clif/clang/bin/clif-matcher --ccdeps_out /home/ryuichi/Dropbox/asr/pykaldi/build/kaldi/chain/chain-datastruct-clifwrap.cc --header_out /home/ryuichi/Dropbox/asr/pykaldi/build/kaldi/chain/chain-datastruct-clifwrap.h --ccinit_out /home/ryuichi/Dropbox/asr/pykaldi/build/kaldi/chain/chain-datastruct-clifwrap-init.cc --modname=_chain_datastruct --prepend=clif/python/types.h -I/home/ryuichi/Dropbox/asr/pykaldi -I/home/ryuichi/Dropbox/asr/pykaldi/kaldi -I/home/ryuichi/Dropbox/asr/pykaldi/build/kaldi -I../kaldi-for-pykaldi/src "-f-I/home/ryuichi/anaconda3/include/python3.6m              -I/home/ryuichi/Dropbox/asr/pykaldi              -I/home/ryuichi/Dropbox/asr/pykaldi/kaldi              -I/home/ryuichi/Dropbox/asr/pykaldi/build/kaldi              -I../kaldi-for-pykaldi/src              -I/home/ryuichi/opt/clif/clang/lib/clang/5.0.0/include               -std=c++11 -I.. -I/home/ryuichi/Dropbox/asr/kaldi-for-pykaldi/tools/openfst/include -Wall -Wno-sign-compare -Wno-unused-local-typedefs -Wno-deprecated-declarations -Winit-self -DKALDI_DOUBLEPRECISION=0 -DHAVE_EXECINFO_H=1 -DHAVE_CXXABI_H -DHAVE_ATLAS -I/home/ryuichi/Dropbox/asr/kaldi-for-pykaldi/tools/ATLAS_headers/include -msse -msse2 -pthread -g -fPIC -DHAVE_CUDA -I/usr/local/cuda/include" /home/ryuichi/Dropbox/asr/pykaldi/kaldi/chain/chain-datastruct.clif
/dev/stdin:2:10: fatal error: 'base/timer.h' file not found
#include "base/timer.h"
         ^~~~~~~~~~~~~~
_BackendError: Matcher failed with status 1
/dev/stdin:2:10: fatal error: 'base/kaldi-error.h' file not found
#include "base/kaldi-error.h"
         ^~~~~~~~~~~~~~~~~~~~
_BackendError: Matcher failed with status 1
kaldi/base/CMakeFiles/_timer_pyclif.dir/build.make:65: recipe for target 'kaldi/base/timer-clifwrap.cc' failed
make[2]: *** [kaldi/base/timer-clifwrap.cc] Error 4
make[2]: Leaving directory '/home/ryuichi/Dropbox/asr/pykaldi/build'
CMakeFiles/Makefile2:244: recipe for target 'kaldi/base/CMakeFiles/_timer_pyclif.dir/all' failed
make[1]: *** [kaldi/base/CMakeFiles/_timer_pyclif.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
/dev/stdin:2:10: fatal error: 'itf/options-itf.h' file not found
#include "itf/options-itf.h"
         ^~~~~~~~~~~~~~~~~~~
kaldi/base/CMakeFiles/_kaldi_error_pyclif.dir/build.make:65: recipe for target 'kaldi/base/kaldi-error-clifwrap.cc' failed
make[2]: *** [kaldi/base/kaldi-error-clifwrap.cc] Error 4
make[2]: Leaving directory '/home/ryuichi/Dropbox/asr/pykaldi/build'
CMakeFiles/Makefile2:431: recipe for target 'kaldi/base/CMakeFiles/_kaldi_error_pyclif.dir/all' failed
make[1]: *** [kaldi/base/CMakeFiles/_kaldi_error_pyclif.dir/all] Error 2
_BackendError: Matcher failed with status 1
kaldi/itf/CMakeFiles/_options_itf_pyclif.dir/build.make:65: recipe for target 'kaldi/itf/options-itf-clifwrap.cc' failed
make[2]: *** [kaldi/itf/options-itf-clifwrap.cc] Error 4
make[2]: Leaving directory '/home/ryuichi/Dropbox/asr/pykaldi/build'
CMakeFiles/Makefile2:8517: recipe for target 'kaldi/itf/CMakeFiles/_options_itf_pyclif.dir/all' failed
make[1]: *** [kaldi/itf/CMakeFiles/_options_itf_pyclif.dir/all] Error 2
/dev/stdin:2:10: fatal error: 'base/kaldi-math.h' file not found
#include "base/kaldi-math.h"
         ^~~~~~~~~~~~~~~~~~~
_BackendError: Matcher failed with status 1
cd /home/ryuichi/Dropbox/asr/pykaldi/build/kaldi/base && ../../../tools/use_namespace.sh /home/ryuichi/Dropbox/asr/pykaldi/build/kaldi/base/fstream-clifwrap.cc
make[2]: Leaving directory '/home/ryuichi/Dropbox/asr/pykaldi/build'
[  2%] Built target _fstream_pyclif
kaldi/base/CMakeFiles/_kaldi_math_pyclif.dir/build.make:65: recipe for target 'kaldi/base/kaldi-math-clifwrap.cc' failed
make[2]: *** [kaldi/base/kaldi-math-clifwrap.cc] Error 4
make[2]: Leaving directory '/home/ryuichi/Dropbox/asr/pykaldi/build'
CMakeFiles/Makefile2:847: recipe for target 'kaldi/base/CMakeFiles/_kaldi_math_pyclif.dir/all' failed
make[1]: *** [kaldi/base/CMakeFiles/_kaldi_math_pyclif.dir/all] Error 2
cd /home/ryuichi/Dropbox/asr/pykaldi/build/kaldi/base && ../../../tools/use_namespace.sh /home/ryuichi/Dropbox/asr/pykaldi/build/kaldi/base/sstream-clifwrap.cc
cd /home/ryuichi/Dropbox/asr/pykaldi/build/kaldi/base && ../../../tools/use_namespace.sh /home/ryuichi/Dropbox/asr/pykaldi/build/kaldi/base/iostream-clifwrap.cc
make[2]: Leaving directory '/home/ryuichi/Dropbox/asr/pykaldi/build'
make[2]: Leaving directory '/home/ryuichi/Dropbox/asr/pykaldi/build'
[  2%] Built target _sstream_pyclif
[  2%] Built target _iostream_pyclif
/dev/stdin:2:10: fatal error: 'chain/chain-datastruct.h' file not found
#include "chain/chain-datastruct.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~
_BackendError: Matcher failed with status 1
kaldi/chain/CMakeFiles/_chain_datastruct_pyclif.dir/build.make:65: recipe for target 'kaldi/chain/chain-datastruct-clifwrap.cc' failed
make[2]: *** [kaldi/chain/chain-datastruct-clifwrap.cc] Error 4
make[2]: Leaving directory '/home/ryuichi/Dropbox/asr/pykaldi/build'
CMakeFiles/Makefile2:1079: recipe for target 'kaldi/chain/CMakeFiles/_chain_datastruct_pyclif.dir/all' failed
make[1]: *** [kaldi/chain/CMakeFiles/_chain_datastruct_pyclif.dir/all] Error 2
make[1]: Leaving directory '/home/ryuichi/Dropbox/asr/pykaldi/build'
Makefile:86: recipe for target 'all' failed
make: *** [all] Error 2
Command '['make', '-j', '8']' returned non-zero exit status 2.
```