### PR TITLE
Add wrapper for new access functions to the posteriors of the nnet

### DIFF
--- a/examples/scripts/asr/nnet3-keep-loglikes.py
+++ b/examples/scripts/asr/nnet3-keep-loglikes.py
@@ -63,7 +63,7 @@ for key, wav in SequentialWaveReader("scp:wav.scp"):
             feat_pipeline.input_finished()
         nr = d.num_frames_ready()
         if nr > prev_num_frames_computed:
-            x = d.log_likelihoods(prev_num_frames_computed, nr).numpy()
+            x = d.log_likelihoods(prev_num_frames_computed, nr - prev_num_frames_computed).numpy()
             print(x.shape, x)
             prev_num_frames_computed = nr
         asr.advance_decoding()

--- a/examples/scripts/asr/nnet3-keep-loglikes.py
+++ b/examples/scripts/asr/nnet3-keep-loglikes.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+## This script is very similar to the second part in ./nnet3-online-recognizer.py,
+## but it has additional code to extract the log_likelihoods from the nnet
+## during decoding.  Instead of dumping to stdout, the numpy arrays could be saved
+## to disc for later recognition using a script similar to ./mapped-loglikes-recognizer.py. 
+
+from __future__ import print_function
+
+from kaldi.asr import NnetLatticeFasterOnlineRecognizer
+from kaldi.decoder import LatticeFasterDecoderOptions
+from kaldi.nnet3 import NnetSimpleLoopedComputationOptions
+from kaldi.online2 import (OnlineEndpointConfig,
+                           OnlineIvectorExtractorAdaptationState,
+                           OnlineNnetFeaturePipelineConfig,
+                           OnlineNnetFeaturePipelineInfo,
+                           OnlineNnetFeaturePipeline,
+                           OnlineSilenceWeighting)
+from kaldi.util.options import ParseOptions
+from kaldi.util.table import SequentialWaveReader
+
+chunk_size = 1440
+
+# Define online feature pipeline
+feat_opts = OnlineNnetFeaturePipelineConfig()
+endpoint_opts = OnlineEndpointConfig()
+po = ParseOptions("")
+feat_opts.register(po)
+endpoint_opts.register(po)
+po.read_config_file("online.conf")
+feat_info = OnlineNnetFeaturePipelineInfo.from_config(feat_opts)
+
+# Construct recognizer
+decoder_opts = LatticeFasterDecoderOptions()
+decoder_opts.beam = 23
+decoder_opts.max_active = 7000
+decodable_opts = NnetSimpleLoopedComputationOptions()
+decodable_opts.acoustic_scale = 1.0
+decodable_opts.frame_subsampling_factor = 3
+decodable_opts.frames_per_chunk = 50 ## smallish to force many updates
+asr = NnetLatticeFasterOnlineRecognizer.from_files(
+    "final.mdl", "HCLG.fst", "words.txt",
+    decoder_opts=decoder_opts,
+    decodable_opts=decodable_opts,
+    endpoint_opts=endpoint_opts)
+
+# Decode (chunked + partial output + log_likelihoods)
+for key, wav in SequentialWaveReader("scp:wav.scp"):
+    feat_pipeline = OnlineNnetFeaturePipeline(feat_info)
+    asr.set_input_pipeline(feat_pipeline)
+    d = asr._decodable
+    asr.init_decoding()
+    data = wav.data()[0]
+    last_chunk = False
+    part = 1
+    prev_num_frames_decoded = 0
+    prev_num_frames_computed = 0
+    for i in range(0, len(data), chunk_size):
+        if i + chunk_size >= len(data):
+            last_chunk = True
+        feat_pipeline.accept_waveform(wav.samp_freq, data[i:i + chunk_size])
+        if last_chunk:
+            feat_pipeline.input_finished()
+        nr = d.num_frames_ready()
+        if nr > prev_num_frames_computed:
+            x = d.log_likelihoods(prev_num_frames_computed, nr).numpy()
+            print(x.shape, x)
+            prev_num_frames_computed = nr
+        asr.advance_decoding()
+        num_frames_decoded = asr.decoder.num_frames_decoded()
+        if not last_chunk:
+            if num_frames_decoded > prev_num_frames_decoded:
+                prev_num_frames_decoded = num_frames_decoded
+                out = asr.get_partial_output()
+                print(key + "-part%d" % part, out["text"], flush=True)
+                part += 1
+    asr.finalize_decoding()
+    out = asr.get_output()
+    print(key + "-final", out["text"], flush=True)
+

--- a/kaldi/nnet3/CMakeLists.txt
+++ b/kaldi/nnet3/CMakeLists.txt
@@ -201,11 +201,11 @@ add_pyclif_library("_nnet_am_decodable_simple" nnet-am-decodable-simple.clif
 )
 
 add_pyclif_library("_decodable_simple_looped" decodable-simple-looped.clif
-  CLIF_DEPS _transition_model _am_nnet_simple _nnet_compute _nnet_optimize
+  CLIF_DEPS _transition_model _am_nnet_simple _nnet_compute _nnet_optimize 
   LIBRARIES kaldi-util kaldi-nnet3
 )
 
 add_pyclif_library("_decodable_online_looped" decodable-online-looped.clif
-  CLIF_DEPS _online_feature_itf _decodable_simple_looped
+  CLIF_DEPS _online_feature_itf _decodable_simple_looped _matrix_ext
   LIBRARIES kaldi-nnet3
 )

--- a/kaldi/nnet3/CMakeLists.txt
+++ b/kaldi/nnet3/CMakeLists.txt
@@ -206,6 +206,6 @@ add_pyclif_library("_decodable_simple_looped" decodable-simple-looped.clif
 )
 
 add_pyclif_library("_decodable_online_looped" decodable-online-looped.clif
-  CLIF_DEPS _online_feature_itf _decodable_simple_looped _matrix_ext
+  CLIF_DEPS _online_feature_itf _decodable_simple_looped
   LIBRARIES kaldi-nnet3
 )

--- a/kaldi/nnet3/decodable-online-looped.clif
+++ b/kaldi/nnet3/decodable-online-looped.clif
@@ -1,6 +1,7 @@
 from "itf/online-feature-itf-clifwrap.h" import *
 from "hmm/transition-model-clifwrap.h" import *
 from "nnet3/decodable-simple-looped-clifwrap.h" import *
+from "matrix/matrix-ext.h" import *
 
 from kaldi.itf._decodable_itf import DecodableInterface
 
@@ -27,6 +28,9 @@ from "nnet3/decodable-online-looped.h":
       def `FrameSubsamplingFactor` as frame_subsampling_factor(self) -> int:
         """Returns the frame subsampling factor."""
 
+      def `LogLikelihoods` as log_likelihoods(self, frame: int) -> SubVector:
+        """Returns the log-likelihoods for the given frame"""
+
     class DecodableAmNnetLoopedOnline(DecodableInterface):
       """DecodableAmNnetLoopedOnline"""
       def __init__(self, trans_model: TransitionModel,
@@ -48,3 +52,7 @@ from "nnet3/decodable-online-looped.h":
 
       def `FrameSubsamplingFactor` as frame_subsampling_factor(self) -> int:
         """Returns the frame subsampling factor."""
+
+      def `LogLikelihoods` as log_likelihoods(self, frame: int) -> SubVector:
+        """Returns the log-likelihoods for the given frame"""
+

--- a/kaldi/nnet3/decodable-online-looped.clif
+++ b/kaldi/nnet3/decodable-online-looped.clif
@@ -2,8 +2,10 @@ from "itf/online-feature-itf-clifwrap.h" import *
 from "hmm/transition-model-clifwrap.h" import *
 from "nnet3/decodable-simple-looped-clifwrap.h" import *
 from "matrix/kaldi-vector-clifwrap.h" import *
+from "matrix/kaldi-matrix-clifwrap.h" import *
 
 from kaldi.matrix._matrix import _vector_wrapper
+from kaldi.matrix._matrix import _matrix_wrapper
 from kaldi.itf._decodable_itf import DecodableInterface
 
 from "nnet3/decodable-online-looped.h":
@@ -29,7 +31,7 @@ from "nnet3/decodable-online-looped.h":
       def `FrameSubsamplingFactor` as frame_subsampling_factor(self) -> int:
         """Returns the frame subsampling factor."""
 
-      def `LogLikelihoods` as log_likelihoods(self, frame: int) -> Vector:
+      def `LogLikelihoods` as log_likelihoods_frame(self, frame: int) -> Vector:
         """Returns the log-likelihoods for the given frame"""
         return _vector_wrapper(...)
 
@@ -55,7 +57,11 @@ from "nnet3/decodable-online-looped.h":
       def `FrameSubsamplingFactor` as frame_subsampling_factor(self) -> int:
         """Returns the frame subsampling factor."""
 
-      def `LogLikelihoods` as log_likelihoods(self, frame: int) -> Vector:
+      def `LogLikelihoods` as log_likelihoods_frame(self, frame: int) -> Vector:
         """Returns the log-likelihoods for the given frame"""
 	return _vector_wrapper(...)
+
+      def `LogLikelihoods` as log_likelihoods(self, frame_from: int, frame_to: int) -> Matrix:
+        """Returns the log-likelihoods for the given frame"""
+	return _matrix_wrapper(...)
 

--- a/kaldi/nnet3/decodable-online-looped.clif
+++ b/kaldi/nnet3/decodable-online-looped.clif
@@ -35,6 +35,10 @@ from "nnet3/decodable-online-looped.h":
         """Returns the log-likelihoods for the given frame"""
         return _vector_wrapper(...)
 
+      def `LogLikelihoods` as log_likelihoods(self, frame: int, num_frames: int) -> Matrix:
+        """Returns the log-likelihoods for the given frame"""
+	return _matrix_wrapper(...)
+
     class DecodableAmNnetLoopedOnline(DecodableInterface):
       """DecodableAmNnetLoopedOnline"""
       def __init__(self, trans_model: TransitionModel,
@@ -61,7 +65,7 @@ from "nnet3/decodable-online-looped.h":
         """Returns the log-likelihoods for the given frame"""
 	return _vector_wrapper(...)
 
-      def `LogLikelihoods` as log_likelihoods(self, frame_from: int, frame_to: int) -> Matrix:
+      def `LogLikelihoods` as log_likelihoods(self, frame: int, num_frames: int) -> Matrix:
         """Returns the log-likelihoods for the given frame"""
 	return _matrix_wrapper(...)
 

--- a/kaldi/nnet3/decodable-online-looped.clif
+++ b/kaldi/nnet3/decodable-online-looped.clif
@@ -1,8 +1,9 @@
 from "itf/online-feature-itf-clifwrap.h" import *
 from "hmm/transition-model-clifwrap.h" import *
 from "nnet3/decodable-simple-looped-clifwrap.h" import *
-from "matrix/matrix-ext.h" import *
+from "matrix/kaldi-vector-clifwrap.h" import *
 
+from kaldi.matrix._matrix import _vector_wrapper
 from kaldi.itf._decodable_itf import DecodableInterface
 
 from "nnet3/decodable-online-looped.h":
@@ -28,8 +29,9 @@ from "nnet3/decodable-online-looped.h":
       def `FrameSubsamplingFactor` as frame_subsampling_factor(self) -> int:
         """Returns the frame subsampling factor."""
 
-      def `LogLikelihoods` as log_likelihoods(self, frame: int) -> SubVector:
+      def `LogLikelihoods` as log_likelihoods(self, frame: int) -> Vector:
         """Returns the log-likelihoods for the given frame"""
+        return _vector_wrapper(...)
 
     class DecodableAmNnetLoopedOnline(DecodableInterface):
       """DecodableAmNnetLoopedOnline"""
@@ -53,6 +55,7 @@ from "nnet3/decodable-online-looped.h":
       def `FrameSubsamplingFactor` as frame_subsampling_factor(self) -> int:
         """Returns the frame subsampling factor."""
 
-      def `LogLikelihoods` as log_likelihoods(self, frame: int) -> SubVector:
+      def `LogLikelihoods` as log_likelihoods(self, frame: int) -> Vector:
         """Returns the log-likelihoods for the given frame"""
+	return _vector_wrapper(...)
 

--- a/kaldi/nnet3/decodable-online-looped.clif
+++ b/kaldi/nnet3/decodable-online-looped.clif
@@ -36,7 +36,7 @@ from "nnet3/decodable-online-looped.h":
         return _vector_wrapper(...)
 
       def `LogLikelihoods` as log_likelihoods(self, frame: int, num_frames: int) -> Matrix:
-        """Returns the log-likelihoods for the given frame"""
+        """Returns the log-likelihoods for the given frames"""
 	return _matrix_wrapper(...)
 
     class DecodableAmNnetLoopedOnline(DecodableInterface):
@@ -66,6 +66,6 @@ from "nnet3/decodable-online-looped.h":
 	return _vector_wrapper(...)
 
       def `LogLikelihoods` as log_likelihoods(self, frame: int, num_frames: int) -> Matrix:
-        """Returns the log-likelihoods for the given frame"""
+        """Returns the log-likelihoods for the given frames"""
 	return _matrix_wrapper(...)
 


### PR DESCRIPTION
This is my go at adding access to the NNet posteriors via pykaldi, see #113.  I've done this without understanding much of CLIF, or the way pykaldi has wrapped kaldi, but at least it builds and the resulting pykaldi loads... It assumes [this PR](https://github.com/pykaldi/kaldi/pull/1) has been applied to pykaldi/kaldi.  

I need a little help at this stage, as activating this code crashes pykaldi/kaldi left, right and centre.  Based on [nnet-online-recognizer](https://github.com/pykaldi/pykaldi/blob/b0ac6c1816915bb1298eab530818dfc784f2f480/examples/scripts/asr/nnet3-online-recognizer.py#L43-L49) I activate this code by replacing the highlighted lines by
```python
for key, wav in SequentialWaveReader("scp:local/wav.scp"):
    feat_pipeline = OnlineNnetFeaturePipeline(feat_info)
    asr.set_input_pipeline(feat_pipeline)
    d = asr._decodable
    feat_pipeline.accept_waveform(wav.samp_freq, wav.data()[0])
    print(d.num_frames_ready())
    for i in range(d.num_frames_ready()):
        x = d.log_likelihoods(i)
        print(dir(x))
    feat_pipeline.input_finished()
    out = asr.decode()
    print(key, out["text"], flush=True)
```
and actually after the `feat_pipeline.input_finished()` I would need some more `d.log_likelihoods()` statements. 

Currently, this segfaults, so there obviously are things I am doing wrong and/or assumptions I make that don't hold.  

I think the access to the Nnet's [`current_log_post_`](https://github.com/pykaldi/kaldi/blob/cfe1c0ac4be77e3fb4f2555fac2c9ad8f63ae57a/src/nnet3/decodable-online-looped.cc#L244) is correct---but this results in a kaldi SubVector, and I suppose this needs proper copying or reference counting or whatever it takes to make sure the memory is still intact by the time pykaldi wants to use it.  

Then CLIF does its default thing, so the return type in python is `<class 'kaldi.matrix._matrix_ext.SubVector'>`.  This may need an explicit constructor wrapper.  

Any help is greatly appreciated!