### PR TITLE
fix memory leak bug of PyObj2Matrix

### DIFF
--- a/kaldi/matrix/matrix-ext.cc
+++ b/kaldi/matrix/matrix-ext.cc
@@ -127,6 +127,7 @@ static PyObject* _allocator(PyTypeObject* type, Py_ssize_t nitems);
 static int _ctor(PyObject* self, PyObject* args, PyObject* kw);
 
 static void _deallocator(PyObject* self) {
+  reinterpret_cast<wrapper*>(self)->cpp.Destruct();
   Py_XDECREF(reinterpret_cast<wrapper*>(self)->base);
   Py_TYPE(self)->tp_free(self);
 }
@@ -350,6 +351,7 @@ static PyObject* _allocator(PyTypeObject* type, Py_ssize_t nitems);
 static int _ctor(PyObject* self, PyObject* args, PyObject* kw);
 
 static void _deallocator(PyObject* self) {
+  reinterpret_cast<wrapper*>(self)->cpp.Destruct();
   Py_XDECREF(reinterpret_cast<wrapper*>(self)->base);
   Py_TYPE(self)->tp_free(self);
 }
@@ -558,6 +560,7 @@ static PyObject* _allocator(PyTypeObject* type, Py_ssize_t nitems);
 static int _ctor(PyObject* self, PyObject* args, PyObject* kw);
 
 static void _deallocator(PyObject* self) {
+  reinterpret_cast<wrapper*>(self)->cpp.Destruct();
   Py_XDECREF(reinterpret_cast<wrapper*>(self)->base);
   Py_TYPE(self)->tp_free(self);
 }
@@ -781,6 +784,7 @@ static PyObject* _allocator(PyTypeObject* type, Py_ssize_t nitems);
 static int _ctor(PyObject* self, PyObject* args, PyObject* kw);
 
 static void _deallocator(PyObject* self) {
+  reinterpret_cast<wrapper*>(self)->cpp.Destruct();
   Py_XDECREF(reinterpret_cast<wrapper*>(self)->base);
   Py_TYPE(self)->tp_free(self);
 }


### PR DESCRIPTION
hi, I found a bug about pykaldi memory leak while  using PyObj to matix/vector ([ issues ](https://github.com/pykaldi/pykaldi/issues/124))

and I try to fix it, now it work for me .
