### PR TITLE
SequentialReader __iter__ fixed.

### DIFF
--- a/kaldi/util/table.py
+++ b/kaldi/util/table.py
@@ -48,8 +48,10 @@ class _SequentialReaderBase(object):
 
     def __iter__(self):
         while not self.done():
-            yield self.key(), self.value()
+            key = self.key()
+            value = self.value()
             self.next()
+            yield key, value
 
     def open(self, rspecifier):
         """Opens the table for reading.


### PR DESCRIPTION
SequentialReader doesn't repeat the last key, value pair if we use break inside a for loop and then reuse the same reader in another for loop.

```
from kaldi.util.table import SequentialMatrixReader

reader = SequentialMatrixReader("ark,t:echo -e 'a []\nb []\n' |")

for utt, feats in reader:
    assert utt == 'a'
    break

for utt, feats in reader:
    assert utt == 'b'
    break
```
