### PR TITLE
move Docker image to ubuntu:18.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for building PyKaldi image from Ubuntu 16.04 image
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # Install necessary system packages
 RUN apt-get update \

--- a/docker/Dockerfile.min
+++ b/docker/Dockerfile.min
@@ -1,5 +1,5 @@
 # Dockerfile for building PyKaldi min image
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # We do this in a single RUN so that it does not add weight by creating layers
 RUN apt-get update \


### PR DESCRIPTION
I believe the information below (evidence of builds of 18.04) for both `Dockerfile` and `Dockerfile.min` should be all that is required. I've have had to add `apt -y install sox` (see issue https://github.com/pykaldi/pykaldi/issues/212) although this was required for both ubuntu 16.04 and 18.04..

# Evidence of completed 18.04 Dockerfile Build

```
Processing dependencies for pykaldi==0.1.2
Searching for numpy==1.18.2
Best match: numpy 1.18.2
Adding numpy 1.18.2 to easy-install.pth file
Installing f2py script to /usr/local/bin
Installing f2py3 script to /usr/local/bin
Installing f2py3.6 script to /usr/local/bin

Using /usr/local/lib/python3.6/dist-packages
Finished processing dependencies for pykaldi==0.1.2
Removing intermediate container d2b948194f65
 ---> eb70cb336a44
Successfully built eb70cb336a44
Successfully tagged pykaldi/pykaldi:latest
```

# Evidence of completed 18.04 Dockerfile.min Build

```
Processing /pykaldi/tools/clif
Requirement already satisfied: setuptools>=18.5 in /usr/local/lib/python3.6/dist-packages (from pyclif==0.3) (46.1.3)
Requirement already satisfied: pyparsing>=2.2.0 in /usr/local/lib/python3.6/dist-packages (from pyclif==0.3) (2.4.6)
Requirement already satisfied: protobuf>=3.2 in /usr/local/lib/python3.6/dist-packages/protobuf-3.11.4-py3.6.egg (from pyclif==0.3) (3.11.4)
Requirement already satisfied: six>=1.9 in /usr/local/lib/python3.6/dist-packages (from protobuf>=3.2->pyclif==0.3) (1.14.0)
Building wheels for collected packages: pyclif
  Building wheel for pyclif (setup.py): started
  Building wheel for pyclif (setup.py): finished with status 'done'
  Created wheel for pyclif: filename=pyclif-0.3-cp36-cp36m-linux_x86_64.whl size=945432 sha256=be88624c5ebaa2a915675dea4c4652c3454a859d186a568ef594e2d61f7a2937
  Stored in directory: /tmp/pip-ephem-wheel-cache-fhr3nawu/wheels/c9/c8/fe/c9af8b4939ce79c213ee1db2d0f8a33473c3b1afea04fa1270
Successfully built pyclif
Installing collected packages: pyclif
Successfully installed pyclif-0.3
Done installing CLIF.
Removing intermediate container c4b526c6b341
 ---> 304d15cc07df
Successfully built 304d15cc07df
Successfully tagged pykaldi/pykaldimin:latest
```

## Workaround for Dockerfile.min Build Failure on "cub" requirement.

Both builds with `Dockerfile.min` for ubuntu 16.04 and 18.04 failed with the error below:

```
ln -s openfst-1.6.7 openfst
Configuring ...
Checking compiler g++ ...
Checking OpenFst library in /kaldi/tools/openfst ...
Checking cub library in  ...
***configure failed: Could not find file /cub/cub.cuh:
  you may not have installed cub.  Go to ../tools/ and type
  e.g. 'make cub'; cub is a new requirement. ***
```

I worked around this by modifying the line `./configure --shared` to `./configure --use-cuda=no --shared` and the build was complete. I did not see a similar issue with a build from the `Dockerfile` image.