### PR TITLE
tools/install_clif OSX and XCODE version-specific fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ if KALDI_TFRNNLM:
     subprocess.check_call(["rm", "Makefile"])
 
 if platform.system() == "Darwin":
+    XCODE_SDK_DIR = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
     XCODE_TOOLCHAIN_DIR = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain"
     COMMAND_LINE_TOOLCHAIN_DIR = "/Library/Developer/CommandLineTools"
     if os.path.isdir(XCODE_TOOLCHAIN_DIR):
@@ -128,7 +129,11 @@ if platform.system() == "Darwin":
         sys.exit(1)
     CXX_SYSTEM_INCLUDE_DIR = os.path.join(TOOLCHAIN_DIR, "usr/include/c++/v1")
     CLIF_CXX_FLAGS += " -isystem {}".format(CXX_SYSTEM_INCLUDE_DIR)
+    if os.path.isdir(XCODE_SDK_DIR):
+        CXX_SYSTEM_INCLUDE_DIR = os.path.join(XCODE_SDK_DIR, "usr/include")
+        CLIF_CXX_FLAGS += " -isystem {}".format(CXX_SYSTEM_INCLUDE_DIR)
     LD_FLAGS += " -undefined dynamic_lookup"
+    print(CLIF_CXX_FLAGS)
 elif platform.system() == "Linux":
     CXX_FLAGS += " -Wno-maybe-uninitialized"
     LD_FLAGS += " -Wl,--as-needed"

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,6 @@ if platform.system() == "Darwin":
         CXX_SYSTEM_INCLUDE_DIR = os.path.join(XCODE_SDK_DIR, "usr/include")
         CLIF_CXX_FLAGS += " -isystem {}".format(CXX_SYSTEM_INCLUDE_DIR)
     LD_FLAGS += " -undefined dynamic_lookup"
-    print(CLIF_CXX_FLAGS)
 elif platform.system() == "Linux":
     CXX_FLAGS += " -Wno-maybe-uninitialized"
     LD_FLAGS += " -Wl,--as-needed"

--- a/tools/install_clif.sh
+++ b/tools/install_clif.sh
@@ -175,7 +175,6 @@ cmake -DCMAKE_INSTALL_PREFIX="$PYTHON_ENV/clang" \
 cd "$CLIF_DIR"
 # Grab the python compiled .proto
 cp "$BUILD_DIR/tools/clif/protos/ast_pb2.py" clif/protos/
-error: cannot initialize a member subobject of type 'Py_ssize_t' (aka 'long') with an rvalue of type 'nullptr_t'# Grab CLIF generated wrapper implementation for proto_util.
 cp "$BUILD_DIR/tools/clif/python/utils/proto_util.cc" clif/python/utils/
 cp "$BUILD_DIR/tools/clif/python/utils/proto_util.h" clif/python/utils/
 cp "$BUILD_DIR/tools/clif/python/utils/proto_util.init.cc" clif/python/utils/

--- a/tools/install_clif.sh
+++ b/tools/install_clif.sh
@@ -87,8 +87,11 @@ CXX_SYSTEM_INCLUDE_DIR_FLAGS=
 if [ "`uname`" == "Darwin" ]; then
   PYCLIF_CFLAGS="${PYCLIF_CFLAGS} -stdlib=libc++"
   XCODE_TOOLCHAIN_DIR="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain"
+  XCODE_SDK_DIR="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
   COMMAND_LINE_TOOLCHAIN_DIR="/Library/Developer/CommandLineTools"
-  if [ -d "$XCODE_TOOLCHAIN_DIR" ]; then
+  if [ -d "$XCODE_SDK_DIR" ]; then
+    CXX_SYSTEM_INCLUDE_DIR="${XCODE_SDK_DIR}/usr/include"
+  elif [ -d "$XCODE_TOOLCHAIN_DIR" ]; then
     CXX_SYSTEM_INCLUDE_DIR="${XCODE_TOOLCHAIN_DIR}/usr/include/c++/v1"
   elif [ -d "$COMMAND_LINE_TOOLCHAIN_DIR" ]; then
     CXX_SYSTEM_INCLUDE_DIR="${COMMAND_LINE_TOOLCHAIN_DIR}/usr/include/c++/v1"
@@ -97,7 +100,6 @@ if [ "`uname`" == "Darwin" ]; then
     echo "Install xcode command line tools, e.g. xcode-select --install"
     exit 1
   fi
-  CXX_SYSTEM_INCLUDE_DIR="${CXX_SYSTEM_INCLUDE_DIR} -isystem /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"
   CXX_SYSTEM_INCLUDE_DIR_FLAGS="-DCXX_SYSTEM_INCLUDE_DIR=$CXX_SYSTEM_INCLUDE_DIR"
 fi
 

--- a/tools/install_clif.sh
+++ b/tools/install_clif.sh
@@ -97,6 +97,7 @@ if [ "`uname`" == "Darwin" ]; then
     echo "Install xcode command line tools, e.g. xcode-select --install"
     exit 1
   fi
+  CXX_SYSTEM_INCLUDE_DIR="${CXX_SYSTEM_INCLUDE_DIR} -isystem /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"
   CXX_SYSTEM_INCLUDE_DIR_FLAGS="-DCXX_SYSTEM_INCLUDE_DIR=$CXX_SYSTEM_INCLUDE_DIR"
 fi
 

--- a/tools/install_clif.sh
+++ b/tools/install_clif.sh
@@ -87,11 +87,9 @@ CXX_SYSTEM_INCLUDE_DIR_FLAGS=
 if [ "`uname`" == "Darwin" ]; then
   PYCLIF_CFLAGS="${PYCLIF_CFLAGS} -stdlib=libc++"
   XCODE_TOOLCHAIN_DIR="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain"
-  XCODE_SDK_DIR="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+  XCODE_SDK_DIR="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include"
   COMMAND_LINE_TOOLCHAIN_DIR="/Library/Developer/CommandLineTools"
-  if [ -d "$XCODE_SDK_DIR" ]; then
-    CXX_SYSTEM_INCLUDE_DIR="${XCODE_SDK_DIR}/usr/include"
-  elif [ -d "$XCODE_TOOLCHAIN_DIR" ]; then
+  if [ -d "$XCODE_TOOLCHAIN_DIR" ]; then
     CXX_SYSTEM_INCLUDE_DIR="${XCODE_TOOLCHAIN_DIR}/usr/include/c++/v1"
   elif [ -d "$COMMAND_LINE_TOOLCHAIN_DIR" ]; then
     CXX_SYSTEM_INCLUDE_DIR="${COMMAND_LINE_TOOLCHAIN_DIR}/usr/include/c++/v1"
@@ -99,6 +97,9 @@ if [ "`uname`" == "Darwin" ]; then
     echo "Could not find toolchain directory!"
     echo "Install xcode command line tools, e.g. xcode-select --install"
     exit 1
+  fi
+  if [ -d "$XCODE_SDK_DIR" ]; then
+    CXX_SYSTEM_INCLUDE_DIR="${CXX_SYSTEM_INCLUDE_DIR} -isystem ${XCODE_SDK_DIR}"
   fi
   CXX_SYSTEM_INCLUDE_DIR_FLAGS="-DCXX_SYSTEM_INCLUDE_DIR=$CXX_SYSTEM_INCLUDE_DIR"
 fi
@@ -174,7 +175,7 @@ cmake -DCMAKE_INSTALL_PREFIX="$PYTHON_ENV/clang" \
 cd "$CLIF_DIR"
 # Grab the python compiled .proto
 cp "$BUILD_DIR/tools/clif/protos/ast_pb2.py" clif/protos/
-# Grab CLIF generated wrapper implementation for proto_util.
+error: cannot initialize a member subobject of type 'Py_ssize_t' (aka 'long') with an rvalue of type 'nullptr_t'# Grab CLIF generated wrapper implementation for proto_util.
 cp "$BUILD_DIR/tools/clif/python/utils/proto_util.cc" clif/python/utils/
 cp "$BUILD_DIR/tools/clif/python/utils/proto_util.h" clif/python/utils/
 cp "$BUILD_DIR/tools/clif/python/utils/proto_util.init.cc" clif/python/utils/

--- a/tools/install_clif.sh
+++ b/tools/install_clif.sh
@@ -175,6 +175,7 @@ cmake -DCMAKE_INSTALL_PREFIX="$PYTHON_ENV/clang" \
 cd "$CLIF_DIR"
 # Grab the python compiled .proto
 cp "$BUILD_DIR/tools/clif/protos/ast_pb2.py" clif/protos/
+# Grab CLIF generated wrapper implementation for proto_util.
 cp "$BUILD_DIR/tools/clif/python/utils/proto_util.cc" clif/python/utils/
 cp "$BUILD_DIR/tools/clif/python/utils/proto_util.h" clif/python/utils/
 cp "$BUILD_DIR/tools/clif/python/utils/proto_util.init.cc" clif/python/utils/


### PR DESCRIPTION
When I tried to build from source on mac, I couldn't do it. Here's what I fixed for that.
- python 3.6.8
- conda 4.8.3
- macOS Catalina ver. 10.15.6
- Xcode 11.7 