### PR TITLE
Resolve "examples/setups/zamia/models.sh requires update to "20190609"

### DIFF
--- a/examples/setups/zamia/models.sh
+++ b/examples/setups/zamia/models.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 wget --no-check-certificate https://goofy.zamia.org/zamia-speech/asr-models/kaldi-generic-en-tdnn_f-r20190609.tar.xz
-tar -xJf kaldi-generic-en-tdnn_f-r20190227.tar.xz
-rm -f kaldi-generic-en-tdnn_f-r20190227.tar.xz
+tar -xJf kaldi-generic-en-tdnn_f-r20190609.tar.xz
+rm -f kaldi-generic-en-tdnn_f-r20190609.tar.xz
 
-mv kaldi-generic-en-tdnn_f-r20190227/README.md README-ZAMIA.md
-mv kaldi-generic-en-tdnn_f-r20190227/* .
-rm -rf kaldi-generic-en-tdnn_f-r20190227
+mv kaldi-generic-en-tdnn_f-r20190609/README.md README-ZAMIA.md
+mv kaldi-generic-en-tdnn_f-r20190609/* .
+rm -rf kaldi-generic-en-tdnn_f-r20190609
 
 mkdir -p exp/nnet3_chain
 mv model exp/nnet3_chain/tdnn_f
@@ -14,3 +14,4 @@ mv extractor exp/nnet3_chain/.
 mv ivectors_test_hires exp/nnet3_chain/.
 ln -sr exp/nnet3_chain/ivectors_test_hires/conf/ivector_extractor.conf conf/.
 ln -sr ../aspire/data/test data/.
+


### PR DESCRIPTION
Closes #206 

Hi there, I'm muramasa from Japan.
The version of zamia model downloaded on L3 (`kaldi-generic-en-tdnn_f-r20190609`) is different from after that(`kaldi-generic-en-tdnn_f-r20190227`).
So I fixed the bug about version of zamia in `pykaldi/examples/setups/zamia/models.sh`

Please check and merge it!