### PR TITLE
Added bump2version config and explanation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,11 @@
+[bumpversion]
+current_version = 0.2.1
+commit = True
+tag = True
+tag_name = v{new_version}
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<release>(\.dev|rc)[0-9]+)?
+serialize =
+	{major}.{minor}.{patch}{release}
+	{major}.{minor}.{patch}
+
+[bumpversion:file:kaldi/__version__.py]

--- a/README.md
+++ b/README.md
@@ -607,6 +607,25 @@ follows:
 ```
 
 
+## Releases
+
+This project uses [bump2version](https://pypi.org/project/bump2version/) for
+creating new releases. Only the maintainer(s) of this repo should bump versions
+and this should be done only on the master branch. To bump the version first
+install the package `pip3 install bump2version` and then from the command line
+run:
+
+```bash
+    bump2version major/minor/patch
+```
+
+Then push the tags to the repository:
+
+```bash
+    git push && git push --tags
+```
+
+
 ## Contributing
 
 We appreciate all contributions! If you find a bug, feel free to open an issue


### PR DESCRIPTION
This pull request adds a bump2version config so that the increase of versions automatically creates a git tag and a commit with a standard message.

This relates to issues #281 and #237.