### PR TITLE
Add missing types to alignment docs

### DIFF
--- a/kaldi/alignment.py
+++ b/kaldi/alignment.py
@@ -239,7 +239,7 @@ class Aligner(object):
                 includes symbols instead of integer indices.
 
         Returns:
-            List[Tuple[int,int,int]]: A list of triplets representing, for
+            List[Tuple[Union[str,int],int,int]]: A list of triplets representing, for
             each phone in the input, the phone index/symbol, the begin time (in
             frames) and the duration (in frames).
         """
@@ -265,7 +265,7 @@ class Aligner(object):
             word_boundary_info (WordBoundaryInfo): Word boundary information.
 
         Returns:
-            List[Tuple[int,int,int]]: A list of triplets representing, for each
+            List[Tuple[Union[str,int],int,int]]: A list of triplets representing, for each
             word in the input, the word index/symbol, the begin time (in frames)
             and the duration (in frames). The zero/epsilon words correspond to
             optional silences.


### PR DESCRIPTION
`to_phone_alignment` and `to_word_alignment` type signatures were wrong in the docs for the alignment module.
If the phones and symbol tables (Respectively) are present then it returns a string instead of int for the first position in the tuple.