### PR TITLE
Adding attribut allow_upsample in FrameExtractionOptions class

### DIFF
--- a/kaldi/feat/feature-window.clif
+++ b/kaldi/feat/feature-window.clif
@@ -40,7 +40,7 @@ from "feat/feature-window.h":
       """Whether to output only frames that fit in the waveform (default=True)"""
 
       allow_downsample: bool
-      """Whether input waveform can have a higher sampling frequency than specified (default=False)"""
+      """Whether input waveform can have a lower sampling frequency than specified (default=False)"""
 
       allow_upsample: bool
       """Whether input waveform can have a higher sampling frequency than specified (default=False)"""

--- a/kaldi/feat/feature-window.clif
+++ b/kaldi/feat/feature-window.clif
@@ -42,6 +42,9 @@ from "feat/feature-window.h":
       allow_downsample: bool
       """Whether input waveform can have a higher sampling frequency than specified (default=False)"""
 
+      allow_upsample: bool
+      """Whether input waveform can have a higher sampling frequency than specified (default=False)"""
+
       def `Register` as register(self, opts: OptionsItf):
         """Registers options with an object implementing the options interface.
 

--- a/kaldi/feat/feature-window.clif
+++ b/kaldi/feat/feature-window.clif
@@ -40,10 +40,10 @@ from "feat/feature-window.h":
       """Whether to output only frames that fit in the waveform (default=True)"""
 
       allow_downsample: bool
-      """Whether input waveform can have a lower sampling frequency than specified (default=False)"""
+      """Whether input waveform can have a higher sampling frequency than specified (default=False)"""
 
       allow_upsample: bool
-      """Whether input waveform can have a higher sampling frequency than specified (default=False)"""
+      """Whether input waveform can have a lower sampling frequency than specified (default=False)"""
 
       def `Register` as register(self, opts: OptionsItf):
         """Registers options with an object implementing the options interface.


### PR DESCRIPTION
The allow_upsample attribute is missing from the pykaldi binding:
[pykaldi doc](https://pykaldi.github.io/api/kaldi.feat.html?highlight=allow_downsample#kaldi.feat.window.FrameExtractionOptions.allow_downsample) VS [kaldi doc](https://kaldi-asr.org/doc/structkaldi_1_1FrameExtractionOptions.html#ab56e8dfe973f4f6c2754dcd9781a4820)