### PR TITLE
Add a new kind of alignment lattice in speechocean762

### DIFF
--- a/kaldi/decoder/_compiler.py
+++ b/kaldi/decoder/_compiler.py
@@ -61,6 +61,19 @@ class TrainingGraphCompiler(TrainingGraphCompiler):
                      self).compile_graph_from_text(transcript)
         return _fst.StdVectorFst(ofst)
 
+    def compile_graph_from_lg(self, phone2word_fst):
+        """Compiles a single training graph from a weighted acceptor.
+
+        Args:
+            phone2word_fst (StdVectorFst): Weighted acceptor `G` at the word level.
+
+        Returns:
+            StdVectorFst: The training graph `HCLG`.
+        """
+        ofst = super(TrainingGraphCompiler,
+                     self).compile_graph_from_lg(phone2word_fst)
+        return _fst.StdVectorFst(ofst)
+
     def compile_graphs_from_text(self, transcripts):
         """Compiles training graphs from transcripts.
 

--- a/kaldi/decoder/training-graph-compiler-ext.clif
+++ b/kaldi/decoder/training-graph-compiler-ext.clif
@@ -28,6 +28,10 @@ from "decoder/training-graph-compiler-ext.h":
         -> (success: bool, out_fst: StdVectorFst):
         return _value_error_on_false(...)
 
+      def `CompileGraphFromLG` as compile_graph_from_lg(self, phone2word_fst: StdVectorFst)
+        -> (success: bool, out_fst: StdVectorFst):
+        return _value_error_on_false(...)
+
       def `CompileGraphsFromText` as compile_graphs_from_text(self, transcripts: list<list<int>>)
         -> (success: bool, out_fsts: list<StdVectorFst>):
         return _value_error_on_false(...)


### PR DESCRIPTION
According to the paper of [speechocean762](https://www.isca-archive.org/interspeech_2021/zhang21x_interspeech.pdf), they add a new methodology of reading a pre-defined linear FST structure instead of a lexicon.
I reproduce their code in PyKaldi. It helps us to reproduce their work with PyKaldi APIs.

For more details, please read this [commit](https://github.com/kaldi-asr/kaldi/commit/b9890a9).