### PR TITLE
Add dependency on _chain_datastruct in CMakeLists

### DIFF
--- a/kaldi/chain/CMakeLists.txt
+++ b/kaldi/chain/CMakeLists.txt
@@ -2,7 +2,7 @@ set(PACKAGE "${PACKAGE}.chain")
 
 add_pyclif_library("_chain_datastruct" chain-datastruct.clif)
 add_pyclif_library("_chain_den_graph" chain-den-graph.clif
-  CLIF_DEPS _cu_matrixdim _cu_vector _vector_fst _transition_model _context_dep
+  CLIF_DEPS _cu_matrixdim _cu_vector _vector_fst _transition_model _context_dep _chain_datastruct
   LIBRARIES kaldi-chain
 )
 add_pyclif_library("_chain_training" chain-training.clif


### PR DESCRIPTION
Fix a dependency issue which causes ninja build failure, which is mentioned in https://github.com/pykaldi/pykaldi/issues/328